### PR TITLE
Adding "object-cover" property

### DIFF
--- a/components/kit/components/elements/avatars/MultipleAvatar.tsx
+++ b/components/kit/components/elements/avatars/MultipleAvatar.tsx
@@ -17,28 +17,28 @@ const MultipleAvatar = ({ size, withHoverEffect }: Props) => {
     <div className="flex -space-x-2">
       <a href="#" className={`${effectClasses}`}>
         <img
-          className={`inline-block ${sizeClasses} rounded-full ring-2 ring-white`}
+          className={`inline-block ${sizeClasses} rounded-full object-cover ring-2 ring-white`}
           src="/images/person/1.jpg"
           alt="Guy"
         />
       </a>
       <a href="#" className={`${effectClasses}`}>
         <img
-          className={`inline-block ${sizeClasses} rounded-full ring-2 ring-white`}
+          className={`inline-block ${sizeClasses} rounded-full object-cover ring-2 ring-white`}
           src="/images/person/2.jpeg"
           alt="Max"
         />
       </a>
       <a href="#" className={`${effectClasses}`}>
         <img
-          className={`inline-block ${sizeClasses} rounded-full ring-2 ring-white`}
+          className={`inline-block ${sizeClasses} rounded-full object-cover ring-2 ring-white`}
           src="/images/person/3.jpg"
           alt="Charles"
         />
       </a>
       <a href="#" className={`${effectClasses}`}>
         <img
-          className={`inline-block ${sizeClasses} rounded-full ring-2 ring-white`}
+          className={`inline-block ${sizeClasses} rounded-full object-cover ring-2 ring-white`}
           src="/images/person/4.jpg"
           alt="Jade"
         />


### PR DESCRIPTION
Without this property, some images (like "/images/person/3.jpg") get "squeezed" in order to fit the desired size.

#To compare:
1. Go to https://www.tailwind-kit.com/components/avatar
2. Component "Multiple big avatar"
3. Add the property "object-cover" to every object