### PR TITLE
fix chrome logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ At present, we officially aim to support the last two versions of the following 
 
 | Chrome | Firefox | Edge | Safari | Opera |
 |:---:|:---:|:---:|:---:|:---:|
-| <img src="https://github.com/creativetimofficial/public-assets/blob/master/logos/chrome-logo.png?raw=true" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/firefox-logo.png" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/edge-logo.png" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/safari-logo.png" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/opera-logo.png" width="64" height="64"> |
+| <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/chrome-logo.png" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/firefox-logo.png" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/edge-logo.png" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/safari-logo.png" width="64" height="64"> | <img src="https://raw.githubusercontent.com/creativetimofficial/public-assets/master/logos/opera-logo.png" width="64" height="64"> |
 
 ## Reporting Issues/ make Pull request
 

--- a/components/kit/components/list/list/BlockList.tsx
+++ b/components/kit/components/list/list/BlockList.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import Avatar from "../../elements/avatars/Avatar";
+import React from "react";
 
 interface Props {
   withDesc?: boolean;
@@ -70,7 +70,7 @@ const BlockList = (props: Props) => {
                   </div>
                 )}
                 {props.withAction && (
-                  <button className="w-24 text-right">
+                  <button className="w-24 text-right flex justify-end">
                     <svg
                       width="12"
                       fill="currentColor"


### PR DESCRIPTION
The Google Chrome Logo was not showing up in the mobile GitHub app.

Before:
![image](https://user-images.githubusercontent.com/987947/103363065-845d1f80-4aba-11eb-9a61-3ea364940115.png)


After:
![image](https://user-images.githubusercontent.com/987947/103363106-9e96fd80-4aba-11eb-80c5-f15dd8d50cf2.png)
